### PR TITLE
Renamed "Points to Ponder" to "Learning Outcomes"

### DIFF
--- a/ruby_programming/basic_ruby/lesson_advanced_building_blocks.md
+++ b/ruby_programming/basic_ruby/lesson_advanced_building_blocks.md
@@ -122,7 +122,7 @@ Make sure you can do the following quizzes from [Code Quizzes](http://www.codequ
   2. [Quiz #3](http://www.codequizzes.com/ruby/beginner/variable-scope-methods)
   3. [Quiz #4](http://www.codequizzes.com/ruby/beginner/symbols-array-methods-hashes)
   4. [Quiz #6](http://www.codequizzes.com/ruby/beginner/iteration-nested-data-structures)
-  5. Make sure you go back up and look at all the questions from the "Points to Ponder" section. See if you can do most of them without looking back through the text.
+  5. Make sure you go back up and look at all the questions from the "Learning Outcomes" section. See if you can do most of them without looking back through the text.
 </div>
 
 ### Additional Resources

--- a/ruby_programming/basic_ruby/lesson_building_blocks.md
+++ b/ruby_programming/basic_ruby/lesson_building_blocks.md
@@ -124,7 +124,7 @@ Note: If you want to actually write and run your own Ruby code, you can either u
 
 <div class="lesson-content__panel" markdown="1">
   1. Make sure you can do the [Beginner Ruby Quiz #1](http://www.codequizzes.com/ruby/beginner/variables-strings-numbers) from [Code Quizzes](http://www.codequizzes.com/).
-  2. Make sure you go back up and look at all the questions from the "Points to Ponder" section.  See if you can do most of them without looking back through the text.
+  2. Make sure you go back up and look at all the questions from the "Learning Outcomes" section.  See if you can do most of them without looking back through the text.
 </div>
 
 ### Additional Resources

--- a/ruby_programming/intermediate_ruby/lesson_oop.md
+++ b/ruby_programming/intermediate_ruby/lesson_oop.md
@@ -76,7 +76,7 @@ Look through these now and then use them to test yourself after doing the assign
 <div class="lesson-content__panel" markdown="1">
   1. Make sure you can do [Quiz #5](http://www.codequizzes.com/ruby/beginner/intro-object-oriented-programming) from [Code Quizzes](http://www.codequizzes.com).
   2. Make sure you can do [Quiz #7](http://www.codequizzes.com/ruby/beginner/modules-classes-inheritance) as well.
-  3. Make sure you go back up and look at all the questions from the "Points to Ponder" section. See if you can do most of them without looking back through the text.
+  3. Make sure you go back up and look at all the questions from the "Learning Outcomes" section. See if you can do most of them without looking back through the text.
 </div>
 
 ### Additional Resources


### PR DESCRIPTION
## Description

Updated "Points to Ponder" in the "Test Yourself" section to "Learning Outcomes"
Files changed:

- ruby_programming/basic_ruby/lesson_building_blocks.md
- ruby_programming/basic_ruby/lesson_advanced_building_blocks.md
- ruby_programming/intermediate_ruby/lesson_oop.md


## Related Issue
[#859](https://github.com/TheOdinProject/theodinproject/issues/859)

## Motivation and Context
The "Test Yourself" section references a "Points to Ponder" section that is non existent. This probably refers to the "Learning Outcomes" section.
