### PR TITLE
Change link for CS50 Bubble Sort video to Youtube

### DIFF
--- a/ruby_programming/basic_ruby/project_advanced_building_blocks.md
+++ b/ruby_programming/basic_ruby/project_advanced_building_blocks.md
@@ -4,7 +4,7 @@ Sorting algorithms are some of the earliest that you typically get exposed to in
 
 One of the simpler (but more processor-intensive) ways of sorting a group of items in an array is **bubble sort**, where each element is compared to the one next to it and they are swapped if the one on the left is larger than the one on the right.  This continues until the array is eventually sorted.
 
-Check out [this video from Harvard's CS50x on Bubble Sort](http://cs50.tv/2012/fall/shorts/bubble_sort/bubble_sort-720p.mp4).
+Check out [this video from Harvard's CS50x on Bubble Sort](https://www.youtube.com/watch?v=8Kp-8OGwphY).
 
 There's also [an entry on Bubble Sort on Wikipedia](http://en.wikipedia.org/wiki/Bubble_sort) that's worth taking a look at.
 


### PR DESCRIPTION
The video originally listed defaults to 720 resolution. I followed the original URL back to http://cs50.tv/2012/fall/#shorts and they also have a Youtube version available that offers a full selection of resolutions.