### PR TITLE
Replace TryRuby Course with RubyMonk

### DIFF
--- a/web_development_101/the_backend/ruby_basics_lesson.md
+++ b/web_development_101/the_backend/ruby_basics_lesson.md
@@ -30,10 +30,9 @@ Look through these now and then use them to test yourself after doing the assign
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
-
-  1. Go to [tryruby.org](http://tryruby.org) and do the quick exercises there to get your feet wet.  Don't worry about the stuff where they're reading from a file, that's getting deeper than you need to right now.
-  2. Read through the [Ruby in 100 Minutes](http://tutorials.jumpstartlab.com/projects/ruby_in_100_minutes.html) project from Jumpstart Lab.  If you can't get IRB running, check out the [Installations Project](/courses/web-development-101/lessons/installations), which you should have done already.
-  3. Dive in a little deeper by reading chapters 1-10 of Chris Pine's [Learn to Program](http://pine.fm/LearnToProgram/?Chapter=00).  Try to do the exercises at the end of each chapter.  Take a crack at chapter 10, but don't feel disheartened if it still doesn't click for you.  Answers to the exercises are available at [learntoprogramanswers.blogspot.com](http://learntoprogramanswers.blogspot.com/)
+  1. Read through the [Ruby in 100 Minutes](http://tutorials.jumpstartlab.com/projects/ruby_in_100_minutes.html) project from Jumpstart Lab.  If you can't get IRB running, check out the [Installations Project](/courses/web-development-101/lessons/installations), which you should have done already.
+  2. Dive in a little deeper by reading chapters 1-10 of Chris Pine's [Learn to Program](http://pine.fm/LearnToProgram/?Chapter=00).  Try to do the exercises at the end of each chapter.  Take a crack at chapter 10, but don't feel disheartened if it still doesn't click for you.  Answers to the exercises are available at [learntoprogramanswers.blogspot.com](http://learntoprogramanswers.blogspot.com/)
+  3. Finally go through the first five sections of [Ruby Monks Ruby Primer book](https://rubymonk.com/learning/books/1-ruby-primer) (up to and including the Hashes in Ruby section)
 </div>
 
 ### Bonus Assignment:


### PR DESCRIPTION
Codeschool has recently been shut down so we need to replace their TryRuby Course.

I've included the Ruby Monk assignment as the last assignment due to it getting into objects in Ruby. This might be a bit advanced for a student at this level. We should keep an eye out for what students say about it on chat for the next few weeks.