### PR TITLE
delete 3. Codecademy Ruby Project, no longer free resource

### DIFF
--- a/ruby_programming/basic_ruby/lesson_building_blocks.md
+++ b/ruby_programming/basic_ruby/lesson_building_blocks.md
@@ -103,13 +103,12 @@ Look through these now and then use them to test yourself after doing the assign
 
   1. You should have already completed [Learn to Program](http://pine.fm/LearnToProgram/) in the Web Development 101 course to start with.
   2. Do the full [Codecademy Introduction to Ruby section](http://www.codecademy.com/courses/ruby-beginner-en-d1Ylq/0/1) from their [Ruby Track](http://www.codecademy.com/tracks/ruby).
-  3. Complete the [Codecademy Introduction to Ruby](http://www.codecademy.com/courses/ruby-beginner-en-MxXx5/0/1) project ("Putting the Form in Formatter")
-  4. Read [Beginning Ruby](https://books.google.com/books?id=VCQGjDhhbn8C&lpg=PA27&pg=PA13#v=onepage&q&f=false) Chapter 2: `Programming == Joy: A Whistle Stop Tour of Ruby and Object Orientation`
-  5. Read [Beginning Ruby](https://books.google.com/books?id=VCQGjDhhbn8C&lpg=PA27&pg=PA31#v=onepage&q&f=false) Chapter 3: `Ruby's Building Blocks: Data, Expressions, and Flow Control` pages 29-46 (only the section on Numbers and Expressions and the section on Text and Strings)
-  6. Take a look at the [Ruby Date and Time explanation from TutorialsPoint](http://www.tutorialspoint.com/ruby/ruby_date_time.htm).  No need to memorize all the Time Formatting Directives, just know what they are and where to find them.
-  7. Do this great little [Regex Tutorial](http://regexone.com/) and the example problems (should only take an hour or so)
-  8. Glance over this list of [Escape Characters](https://github.com/ruby/ruby/blob/trunk/doc/syntax/literals.rdoc#strings) in Ruby and keep it for future reference.  You'll probably only end up using `\n` newlines and `\t` tabs.
-  9. For a deeper look at certain underserved pieces of the above material, check out these posts from Erik Trautman:
+  3. Read [Beginning Ruby](https://books.google.com/books?id=VCQGjDhhbn8C&lpg=PA27&pg=PA13#v=onepage&q&f=false) Chapter 2: `Programming == Joy: A Whistle Stop Tour of Ruby and Object Orientation`
+  4. Read [Beginning Ruby](https://books.google.com/books?id=VCQGjDhhbn8C&lpg=PA27&pg=PA31#v=onepage&q&f=false) Chapter 3: `Ruby's Building Blocks: Data, Expressions, and Flow Control` pages 29-46 (only the section on Numbers and Expressions and the section on Text and Strings)
+  5. Take a look at the [Ruby Date and Time explanation from TutorialsPoint](http://www.tutorialspoint.com/ruby/ruby_date_time.htm).  No need to memorize all the Time Formatting Directives, just know what they are and where to find them.
+  6. Do this great little [Regex Tutorial](http://regexone.com/) and the example problems (should only take an hour or so)
+  7. Glance over this list of [Escape Characters](https://github.com/ruby/ruby/blob/trunk/doc/syntax/literals.rdoc#strings) in Ruby and keep it for future reference.  You'll probably only end up using `\n` newlines and `\t` tabs.
+  8. For a deeper look at certain underserved pieces of the above material, check out these posts from Erik Trautman:
       1. [Ruby Explained: Numbers, Operators and Expressions](http://www.eriktrautman.com/posts/ruby-explained-numbers-operators-and-expressions)
       2. [Ruby Explained: Objects and Methods](http://www.eriktrautman.com/posts/ruby-explained-objects-and-methods)
       3. [Ruby Explained: Strings](http://www.eriktrautman.com/posts/ruby-explained-strings)


### PR DESCRIPTION
Step 3, the [codecademy ruby project](https://www.codecademy.com/learn/learn-ruby?composer_curriculum_redirect=ruby) (Form in Formatter) is no longer free. 

<img width="838" alt="screen shot 2018-08-28 at 3 32 27 pm" src="https://user-images.githubusercontent.com/13862815/44754653-950abe80-aad7-11e8-9e75-903bb955a5cb.png">

I deleted step 3 and renamed the other steps accordingly to prevent future confusion.

<img width="862" alt="screen shot 2018-08-28 at 3 32 56 pm" src="https://user-images.githubusercontent.com/13862815/44754676-ad7ad900-aad7-11e8-9136-18c407fa2cec.png">
